### PR TITLE
Fix Arg Type Capture + Enable Non-object Standard Types in Infer

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ function* Conversation() {
   yield user`Rank those by order of importance`
 
   // Assistant Message (structured output)
-  const { ranking } = yield* infer(z.object({
-    ranking: z.string().array(),
-  }))
+  const ranking = yield* infer(z.string().array())
 
   return ranking
 }

--- a/examples/deploy-to-cf-worker/worker/conversation.ts
+++ b/examples/deploy-to-cf-worker/worker/conversation.ts
@@ -1,33 +1,33 @@
 import { type } from "arktype"
-import { context, declareLanguageModel, fork, infer, user } from "liminal"
+import * as L from "liminal"
 
-export function* Refine(input: string) {
-  yield* declareLanguageModel("default")
-  yield* user(input)
-  yield* infer()
-  yield* user`Rewrite it in whatever way you think best.`
-  const variants = yield* fork("variants", {
+export function* refine(input: string) {
+  yield* L.declareLanguageModel("default")
+  yield* L.user(input)
+  yield* L.infer()
+  yield* L.user`Rewrite it in whatever way you think best.`
+  const variants = yield* L.fork("variants", {
     *a() {
-      yield* declareLanguageModel("a")
-      return yield* infer()
+      yield* L.declareLanguageModel("a")
+      return yield* L.infer()
     },
     *b() {
-      yield* declareLanguageModel("b")
-      return yield* infer()
+      yield* L.declareLanguageModel("b")
+      return yield* L.infer()
     },
     *c() {
-      yield* declareLanguageModel("c")
-      return yield* infer()
+      yield* L.declareLanguageModel("c")
+      return yield* L.infer()
     },
   })
-  const best = yield* context("selection", function*() {
-    yield* declareLanguageModel("select")
-    yield* user`
+  const best = yield* L.context("selection", function*() {
+    yield* L.declareLanguageModel("select")
+    yield* L.user`
       Out of the following variants, which is your favorite?:
 
       ${JSON.stringify(variants)}
     `
-    return yield* infer(type("'a' | 'b' | 'c'"))
+    return yield* L.infer(type("'a' | 'b' | 'c'"))
   })
   return variants[best]
 }

--- a/examples/deploy-to-cf-worker/worker/worker.ts
+++ b/examples/deploy-to-cf-worker/worker/worker.ts
@@ -3,7 +3,7 @@ import type { ExportedHandler } from "@cloudflare/workers-types"
 import { exec } from "liminal"
 import { AILanguageModel } from "liminal-ai"
 import { env } from "liminal-common"
-import { Refine } from "./conversation.ts"
+import { refine } from "./conversation.ts"
 
 const openai = createOpenAI({
   apiKey: env.OPENAI_API_KEY,
@@ -13,7 +13,7 @@ export default {
   async fetch(request) {
     const input = await request.text()
     try {
-      const { result } = await exec(Refine(input), {
+      const { result } = await exec(refine(input), {
         bind: {
           default: AILanguageModel(openai("gpt-4o")),
           a: AILanguageModel(openai("gpt-4o-mini")),

--- a/examples/patterns/chaining.ts
+++ b/examples/patterns/chaining.ts
@@ -1,9 +1,9 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { declareLanguageModel, exec, infer, system, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 
-exec(MarketingCopy, {
+L.exec(MarketingCopy, {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
   },
@@ -11,11 +11,12 @@ exec(MarketingCopy, {
 })
 
 function* MarketingCopy() {
-  yield* system`Write persuasive marketing copy for: Buffy The Vampire Slayer. Focus on benefits and emotional appeal.`
-  yield* declareLanguageModel("default")
-  yield* user`Please generate the first draft.`
-  let copy = yield* infer()
-  yield* user`
+  yield* L
+    .system`Write persuasive marketing copy for: Buffy The Vampire Slayer. Focus on benefits and emotional appeal.`
+  yield* L.declareLanguageModel("default")
+  yield* L.user`Please generate the first draft.`
+  let copy = yield* L.infer()
+  yield* L.user`
     Now evaluate this marketing copy for:
 
     1. Presence of call to action (true/false)
@@ -24,13 +25,13 @@ function* MarketingCopy() {
 
     Copy to evaluate: ${copy}
   `
-  const qualityMetrics = yield* infer(type({
+  const qualityMetrics = yield* L.infer(type({
     hasCallToAction: "boolean",
     emotionalAppeal: "number.integer",
     clarity: "number.integer",
   }))
   if (!qualityMetrics.hasCallToAction || qualityMetrics.emotionalAppeal < 7 || qualityMetrics.clarity < 7) {
-    yield* user`
+    yield* L.user`
       Rewrite this marketing copy with:
 
       ${!qualityMetrics.hasCallToAction ? "- A clear call to action" : ""}
@@ -39,7 +40,7 @@ function* MarketingCopy() {
 
       Original copy: ${copy}
     `
-    copy = yield* infer()
+    copy = yield* L.infer()
   }
   return { copy, qualityMetrics }
 }

--- a/examples/patterns/optimizer.ts
+++ b/examples/patterns/optimizer.ts
@@ -1,9 +1,9 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { declareLanguageModel, exec, infer, system, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 
-exec(TranslationWithFeedback("typescript", "I love you!"), {
+L.exec(TranslationWithFeedback("typescript", "I love you!"), {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
   },
@@ -11,18 +11,19 @@ exec(TranslationWithFeedback("typescript", "I love you!"), {
 })
 
 function* TranslationWithFeedback(targetLanguage: string, text: string) {
-  yield* declareLanguageModel("default")
-  yield* system`You are an expert literary translator. Translate the supplied text to the specified target language, preserving tone and cultural nuances.`
-  yield* user`Target language: ${targetLanguage}`
-  yield* user`Text:
+  yield* L.declareLanguageModel("default")
+  yield* L
+    .system`You are an expert literary translator. Translate the supplied text to the specified target language, preserving tone and cultural nuances.`
+  yield* L.user`Target language: ${targetLanguage}`
+  yield* L.user`Text:
 
     ${text}
   `
-  let currentTranslation = yield* infer()
+  let currentTranslation = yield* L.infer()
   let iterations = 0
   const MAX_ITERATIONS = 3
   while (iterations < MAX_ITERATIONS) {
-    yield* user`
+    yield* L.user`
       Evaluate this translation:
 
       Original: ${text}
@@ -34,7 +35,7 @@ function* TranslationWithFeedback(targetLanguage: string, text: string) {
       3. Preservation of nuance
       4. Cultural accuracy
     `
-    const evaluation = yield* infer(type({
+    const evaluation = yield* L.infer(type({
       qualityScore: "1 <= number.integer <= 10",
       preservesTone: "boolean",
       preservesNuance: "boolean",
@@ -50,7 +51,7 @@ function* TranslationWithFeedback(targetLanguage: string, text: string) {
     ) {
       break
     }
-    yield* user`
+    yield* L.user`
       Improve this translation based on the following feedback:
 
       ${evaluation.specificIssues.join("\n")}
@@ -59,7 +60,7 @@ function* TranslationWithFeedback(targetLanguage: string, text: string) {
       Original: ${text}
       Current Translation: ${currentTranslation}
     `
-    currentTranslation = yield* infer()
+    currentTranslation = yield* L.infer()
     iterations++
   }
   return {

--- a/examples/patterns/parallel.ts
+++ b/examples/patterns/parallel.ts
@@ -1,6 +1,6 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { declareLanguageModel, exec, fork, infer, system, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 import { readFile } from "node:fs/promises"
 import { fileURLToPath } from "node:url"
@@ -9,7 +9,7 @@ const code = await readFile(fileURLToPath(import.meta.url), "utf-8")
 
 const LMH = type("'lower' | 'medium' | 'high'")
 
-exec(Review(code), {
+L.exec(Review(code), {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
   },
@@ -17,23 +17,24 @@ exec(Review(code), {
 })
 
 function* Review(code: string) {
-  yield* declareLanguageModel("default")
-  yield* system`You are a technical lead summarizing multiple code reviews. Review the supplied code.`
-  yield* user(code)
-  const reviews = yield* fork("Reviews", {
+  yield* L.declareLanguageModel("default")
+  yield* L.system`You are a technical lead summarizing multiple code reviews. Review the supplied code.`
+  yield* L.user(code)
+  const reviews = yield* L.fork("Reviews", {
     SecurityReview,
     PerformanceReview,
     MaintainabilityReview,
   })
-  yield* user(JSON.stringify(Object.values(reviews), null, 2))
-  yield* user`You are a technical lead summarizing multiple code reviews.`
-  const summary = yield* infer()
+  yield* L.user(JSON.stringify(Object.values(reviews), null, 2))
+  yield* L.user`You are a technical lead summarizing multiple code reviews.`
+  const summary = yield* L.infer()
   return { reviews, summary }
 }
 
 function* SecurityReview() {
-  yield* system`You are an expert in code security. Focus on identifying security vulnerabilities, injection risks, and authentication issues.`
-  return yield* infer(type({
+  yield* L
+    .system`You are an expert in code security. Focus on identifying security vulnerabilities, injection risks, and authentication issues.`
+  return yield* L.infer(type({
     type: "'security'",
     vulnerabilities: "string[]",
     riskLevel: LMH,
@@ -42,8 +43,9 @@ function* SecurityReview() {
 }
 
 function* PerformanceReview() {
-  yield* system`You are an expert in code performance. Focus on identifying performance bottlenecks, memory leaks, and optimization opportunities.`
-  return yield* infer(type({
+  yield* L
+    .system`You are an expert in code performance. Focus on identifying performance bottlenecks, memory leaks, and optimization opportunities.`
+  return yield* L.infer(type({
     type: "'performance'",
     issues: "string[]",
     impact: LMH,
@@ -52,8 +54,9 @@ function* PerformanceReview() {
 }
 
 function* MaintainabilityReview() {
-  yield* system`You are an expert in code quality. Focus on code structure, readability, and adherence to best practices.`
-  return yield* infer(type({
+  yield* L
+    .system`You are an expert in code quality. Focus on code structure, readability, and adherence to best practices.`
+  return yield* L.infer(type({
     type: "'maintainability'",
     concerns: "string[]",
     qualityScore: "1 <= number.integer <= 10",

--- a/examples/patterns/placeholding.ts
+++ b/examples/patterns/placeholding.ts
@@ -1,34 +1,31 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { declareLanguageModel, exec, infer, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 
-const departure = Symbol()
-
-exec(PlanTrip, {
+L.exec(PlanTrip("New York City"), {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
-    // [departure]: "New York City",
   },
   handler: console.log,
 })
 
-function* PlanTrip() {
-  yield* declareLanguageModel("default")
-  yield* user`
-    I want to plan a weekend trip leaving from ${departure}. I don't know where to go.
+function* PlanTrip(departureLocation: string) {
+  yield* L.declareLanguageModel("default")
+  yield* L.user`
+    I want to plan a weekend trip leaving from ${departureLocation}. I don't know where to go.
     Suggest some follow-up questions that will help you narrow down the possible destination.
   `
-  const questions = yield* infer(type.string.array())
-  yield* user`Here are my answers to those questions:`
+  const questions = yield* L.infer(type.string.array())
+  yield* L.user`Here are my answers to those questions:`
   for (const question of questions) {
-    yield* user`
+    yield* L.user`
       Question: ${question}
       Answer: ${prompt(question)!}
     `
   }
-  yield* user`Now that we've refined the destination criteria, please provide a single recommendation.`
-  const result = yield* infer()
-  yield* user`Where can I stay there, what can I do there, how do I get there?`
-  return yield* infer()
+  yield* L.user`Now that we've refined the destination criteria, please provide a single recommendation.`
+  const result = yield* L.infer()
+  yield* L.user`Where can I stay there, what can I do there, how do I get there?`
+  return yield* L.infer()
 }

--- a/examples/patterns/routing.ts
+++ b/examples/patterns/routing.ts
@@ -1,9 +1,9 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { context, declareLanguageModel, exec, infer, system, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 
-exec(Main, {
+L.exec(Main, {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
     reasoning: AILanguageModel(openai("o1-mini")),
@@ -12,14 +12,14 @@ exec(Main, {
 })
 
 function* Main() {
-  yield* declareLanguageModel("default")
-  const classification = yield* context("Classification", classifyQuery("I'd like a refund please"))
-  const response = yield* context("ClassificationConsumer", useClassification(classification))
+  yield* L.declareLanguageModel("default")
+  const classification = yield* L.context("Classification", classifyQuery("I'd like a refund please"))
+  const response = yield* L.context("ClassificationConsumer", useClassification(classification))
   return { classification, response }
 }
 
 function* classifyQuery(query: string) {
-  yield* system`
+  yield* L.system`
     Classify this supplied customer query:
 
     Determine:
@@ -28,8 +28,8 @@ function* classifyQuery(query: string) {
     2. Complexity (simple or complex)
     3. Brief reasoning for classification
   `
-  yield* user(query)
-  return yield* infer(Classification)
+  yield* L.user(query)
+  return yield* L.infer(Classification)
 }
 
 const Classification = type({
@@ -39,11 +39,11 @@ const Classification = type({
 })
 
 function* useClassification(classification: typeof Classification.infer) {
-  yield* system(USE_CLASSIFICATION_AGENT_PROMPTS[classification.type])
+  yield* L.system(USE_CLASSIFICATION_AGENT_PROMPTS[classification.type])
   if (classification.complexity === "complex") {
-    yield* declareLanguageModel("reasoning")
+    yield* L.declareLanguageModel("reasoning")
   }
-  return yield* infer()
+  return yield* L.infer()
 }
 
 const USE_CLASSIFICATION_AGENT_PROMPTS = {

--- a/examples/patterns/tool.ts
+++ b/examples/patterns/tool.ts
@@ -1,10 +1,10 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { declareLanguageModel, enableTool, exec, infer, system, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 import * as mathjs from "mathjs"
 
-exec(ToolUser(), {
+L.exec(ToolUser(), {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
   },
@@ -12,12 +12,12 @@ exec(ToolUser(), {
 })
 
 function* ToolUser() {
-  yield* declareLanguageModel("default")
-  yield* system`
+  yield* L.declareLanguageModel("default")
+  yield* L.system`
     You are solving math problems. Reason step by step. Use the calculator when necessary.
     When you give the final answer, provide an explanation for how you arrived at it.
   `
-  const detach = yield* enableTool(
+  const detach = yield* L.enableTool(
     "MathTool",
     `
       A tool for evaluating mathematical expressions. Example expressions:
@@ -27,13 +27,13 @@ function* ToolUser() {
       - \`sin(45 deg) ^ 2\`
     `,
     type.string.array(),
-    (expr) => mathjs.evaluate(expr),
+    mathjs.evaluate,
   )
-  yield* user`
+  yield* L.user`
     A taxi driver earns $9461 per 1-hour of work. If he works 12 hours a day and in 1 hour
     he uses 12 liters of petrol with a price  of $134 for 1 liter. How much money does he earn in one day?
   `
-  const answer = yield* infer()
+  const answer = yield* L.infer()
   yield* detach()
   return answer
 }

--- a/examples/patterns/workers.ts
+++ b/examples/patterns/workers.ts
@@ -1,9 +1,9 @@
 import { openai } from "@ai-sdk/openai"
 import { type } from "arktype"
-import { declareLanguageModel, exec, fork, infer, system, user } from "liminal"
+import * as L from "liminal"
 import { AILanguageModel } from "liminal-ai"
 
-exec(CodeReviewers("Alert administrators via text whenever site traffic exceeds a certain threshold."), {
+L.exec(CodeReviewers("Alert administrators via text whenever site traffic exceeds a certain threshold."), {
   bind: {
     default: AILanguageModel(openai("gpt-4o-mini")),
   },
@@ -11,15 +11,15 @@ exec(CodeReviewers("Alert administrators via text whenever site traffic exceeds 
 })
 
 function* CodeReviewers(feat: string) {
-  yield* system`You are a senior software architect planning feature implementations.`
-  yield* declareLanguageModel("default")
-  yield* user`Analyze this feature request and create an implementation plan:`
-  yield* user(feat)
-  const implementationPlan = yield* infer(type({
+  yield* L.system`You are a senior software architect planning feature implementations.`
+  yield* L.declareLanguageModel("default")
+  yield* L.user`Analyze this feature request and create an implementation plan:`
+  yield* L.user(feat)
+  const implementationPlan = yield* L.infer(type({
     files: FileInfo.array(),
     estimatedComplexity: "'create' | 'medium' | 'high'",
   }))
-  const fileChanges = yield* fork("FileChanges", implementationPlan.files.map((file) => Implementor(feat, file)))
+  const fileChanges = yield* L.fork("FileChanges", implementationPlan.files.map((file) => Implementor(feat, file)))
   return { fileChanges, implementationPlan }
 }
 
@@ -30,8 +30,8 @@ const FileInfo = type({
 })
 
 function* Implementor(featureRequest: string, file: typeof FileInfo.infer) {
-  yield* system(IMPLEMENTATION_PROMPTS[file.changeType])
-  yield* user`
+  yield* L.system(IMPLEMENTATION_PROMPTS[file.changeType])
+  yield* L.user`
     Implement the changes for ${file.filePath} to support:
 
     ${file.purpose}
@@ -40,7 +40,7 @@ function* Implementor(featureRequest: string, file: typeof FileInfo.infer) {
 
     ${featureRequest}
   `
-  const implementation = yield* infer(type({
+  const implementation = yield* L.infer(type({
     explanation: "string",
     code: "string",
   }))

--- a/liminal/Spec.ts
+++ b/liminal/Spec.ts
@@ -4,7 +4,7 @@ import type { Message } from "./actions/Message.ts"
 import type { ActionLike } from "./Actor/ActionLike.ts"
 
 export interface Spec {
-  Field: Record<keyof any, any>
+  Entry: [keyof any, any]
   Event: ActionEvent
 }
 
@@ -16,6 +16,6 @@ export type ExtractSpec<Y extends ActionLike> = MergeSpec<
 >
 
 export type MergeSpec<S extends Spec> = {
-  Field: S["Field"]
+  Entry: S["Entry"]
   Event: S["Event"]
 }

--- a/liminal/actions/Arg.ts
+++ b/liminal/actions/Arg.ts
@@ -7,7 +7,7 @@ export interface Arg<S extends Spec = Spec> extends ActionBase<"arg", S> {
 
 export function arg<K extends keyof any>(key: K): <T>() => Generator<
   Arg<{
-    Field: { [_ in K]: T }
+    Entry: [K, T]
     Event: never
   }>,
   T

--- a/liminal/actions/AssistantMessage.ts
+++ b/liminal/actions/AssistantMessage.ts
@@ -11,7 +11,7 @@ export function* assistant(
   ...[raw, ...substitutions]: [content: AssistantContent] | [raw: TemplateStringsArray, ...substitutions: Array<string>]
 ): Generator<
   AssistantMessage<{
-    Field: never
+    Entry: never
     Event: AssistantMessagedEvent
   }>,
   void

--- a/liminal/actions/Context.ts
+++ b/liminal/actions/Context.ts
@@ -17,7 +17,7 @@ export function* context<K extends keyof any, Y extends ActionLike, S extends Ex
   implementation: ActorLike<Y, T>,
 ): Generator<
   Context<{
-    Field: S["Field"]
+    Entry: S["Entry"]
     Event: ContextEvent<K, EnteredEvent | S["Event"] | ExitedEvent<T>>
   }>,
   T

--- a/liminal/actions/Embed.ts
+++ b/liminal/actions/Embed.ts
@@ -8,7 +8,7 @@ export interface Embed<S extends Spec = Spec> extends ActionBase<"embed", S> {
 
 export function* embed(value: string): Generator<
   Embed<{
-    Field: never
+    Entry: never
     Event: EmbeddedEvent | EmbeddingRequestedEvent
   }>,
   Array<number>

--- a/liminal/actions/Emit.ts
+++ b/liminal/actions/Emit.ts
@@ -9,7 +9,7 @@ export interface Emit<S extends Spec = Spec> extends ActionBase<"emit", S> {
 
 export function* emit<K extends keyof any, V extends JSONValue>(key: K, value: V): Generator<
   Emit<{
-    Field: never
+    Entry: never
     Event: EmittedEvent<K, V>
   }>,
   undefined

--- a/liminal/actions/EnableTool.test-type.ts
+++ b/liminal/actions/EnableTool.test-type.ts
@@ -19,14 +19,14 @@ const arrowTool = enableTool("Tool", "", null! as StandardSchemaV1<P>, (params) 
 })
 
 ActorAssertions(arrowTool).assertSpec<{
-  Field: never
+  Entry: never
   Event: ToolEnabledEvent<"Tool"> | ToolEvent<"Tool", EnteredEvent | ToolCalledEvent<P> | ExitedEvent<void>>
 }>()
 
 function* _0() {
   const detach = yield* arrowTool
   ActorAssertions(detach).assertSpec<{
-    Field: never
+    Entry: never
     Event: ToolDisabledEvent<"Tool">
   }>()
 }
@@ -38,7 +38,7 @@ const genTool = enableTool("Tool", "", null! as StandardSchemaV1<P>, function*(p
 })
 
 ActorAssertions(genTool).assertSpec<{
-  Field: never
+  Entry: never
   Event:
     | ToolEnabledEvent<"Tool">
     | ToolEvent<"Tool", ToolCalledEvent<P> | EnteredEvent | EmittedEvent<"Test", {}> | ExitedEvent<string>>
@@ -52,7 +52,7 @@ function* parent() {
 }
 
 ActorAssertions(parent).assertSpec<{
-  Field: never
+  Entry: never
   Event:
     | ToolEnabledEvent<"ParentTool">
     | ToolEvent<"ParentTool", EnteredEvent | ToolCalledEvent<P> | ExitedEvent<void>>

--- a/liminal/actions/EnableTool.ts
+++ b/liminal/actions/EnableTool.ts
@@ -28,12 +28,12 @@ export function enableTool<K extends keyof any, A extends JSONValue, R extends P
   implementation: (params: A) => R,
 ): Generator<
   EnableTool<{
-    Field: never
+    Entry: never
     Event: ToolEnabledEvent<K> | ToolEvent<K, ToolCalledEvent<A> | EnteredEvent | ExitedEvent<Awaited<R>>>
   }>,
   () => Generator<
     DisableTool<{
-      Field: never
+      Entry: never
       Event: ToolDisabledEvent<K>
     }>,
     void
@@ -51,14 +51,14 @@ export function enableTool<
   implementation: (params: A) => Actor<Y, R>,
 ): Generator<
   EnableTool<{
-    Field: Extract<Y, Action>[""]["Field"]
+    Entry: Extract<Y, Action>[""]["Entry"]
     Event:
       | ToolEnabledEvent<K>
       | ToolEvent<K, ToolCalledEvent<A> | EnteredEvent | Extract<Y, Action>[""]["Event"] | ExitedEvent<Awaited<R>>>
   }>,
   () => Generator<
     DisableTool<{
-      Field: never
+      Entry: never
       Event: ToolDisabledEvent<K>
     }>,
     void

--- a/liminal/actions/Fork.ts
+++ b/liminal/actions/Fork.ts
@@ -21,7 +21,7 @@ export function fork<K extends keyof any, const B extends Array<ActorLike>>(
   Fork<
     {
       // TODO: fix this
-      Field: B[number] extends ActorLike<infer Y> ? ExtractSpec<Y>["Field"] : never
+      Entry: B[number] extends ActorLike<infer Y> ? ExtractSpec<Y>["Entry"] : never
       Event: ForkEvent<
         K,
         | EnteredEvent
@@ -44,7 +44,7 @@ export function fork<K extends keyof any, B extends Record<keyof any, ActorLike>
 ): Generator<
   Fork<
     {
-      Field: B[keyof B] extends ActorLike<infer Y> ? ExtractSpec<Y>["Field"] : never
+      Entry: B[keyof B] extends ActorLike<infer Y> ? ExtractSpec<Y>["Entry"] : never
       Event: ForkEvent<
         K,
         | EnteredEvent

--- a/liminal/actions/Infer.ts
+++ b/liminal/actions/Infer.ts
@@ -11,7 +11,7 @@ export interface Infer<S extends Spec = Spec> extends ActionBase<"infer", S> {
 
 export function infer(): Generator<
   Infer<{
-    Field: never
+    Entry: never
     Event: InferenceRequestedEvent | InferredEvent<string>
   }>,
   string
@@ -20,7 +20,7 @@ export function infer<O extends JSONValue>(
   type: StandardSchemaV1<JSONValue, O>,
 ): Generator<
   Infer<{
-    Field: never
+    Entry: never
     Event: InferenceRequestedEvent | InferredEvent<O>
   }>,
   O

--- a/liminal/actions/SetEmbeddingModel.ts
+++ b/liminal/actions/SetEmbeddingModel.ts
@@ -13,7 +13,7 @@ export type RunEmbed = (action: Embed, scope: Scope) => Promise<Array<number>>
 
 export function* setEmbeddingModel<K extends keyof any>(key: K, runEmbed: RunEmbed): Generator<
   SetEmbeddingModel<{
-    Field: never
+    Entry: never
     Event: EmbeddingModelSetEvent<K>
   }>,
   void

--- a/liminal/actions/SetLanguageModel.ts
+++ b/liminal/actions/SetLanguageModel.ts
@@ -19,7 +19,7 @@ export function* setLanguageModel<K extends keyof any>(
   runInfer: RunInfer,
 ): Generator<
   SetLanguageModel<{
-    Field: never
+    Entry: never
     Event: LanguageModelSetEvent<K>
   }>,
   void

--- a/liminal/actions/SystemMessage.ts
+++ b/liminal/actions/SystemMessage.ts
@@ -10,7 +10,7 @@ export function* system(
   ...[raw, ...substitutions]: [content: string] | [raw: TemplateStringsArray, ...substitutions: Array<string>]
 ): Generator<
   SystemMessage<{
-    Field: never
+    Entry: never
     Event: SystemMessagedEvent
   }>,
   void

--- a/liminal/actions/ToolMessage.ts
+++ b/liminal/actions/ToolMessage.ts
@@ -7,7 +7,7 @@ export interface ToolMessage<S extends Spec = Spec> extends ActionBase<"tool_mes
 
 export function* toolMessage(content: Array<ToolContentPart>): Generator<
   ToolMessage<{
-    Field: never
+    Entry: never
     Event: ToolMessagedEvent
   }>,
   void

--- a/liminal/actions/UserMessage.ts
+++ b/liminal/actions/UserMessage.ts
@@ -17,9 +17,7 @@ export function* user<S extends Array<keyof any> = []>(
   ...[raw, ...substitutions]: [content: UserContent] | [raw: TemplateStringsArray, ...substitutions: S]
 ): Generator<
   UserMessage<{
-    Field: {
-      [K in Extract<S[number], symbol>]: JSONValue
-    }
+    Entry: [Extract<S[number], symbol>, JSONValue]
     Event: UserMessagedEvent
   }>,
   void

--- a/liminal/actions/content_part.ts
+++ b/liminal/actions/content_part.ts
@@ -3,6 +3,7 @@ export interface TextPart {
   text: string
 }
 
+// TODO: URL?
 export type DataContent = string | Uint8Array | ArrayBuffer | Buffer
 
 export interface FilePart {
@@ -46,12 +47,6 @@ export interface ToolCallPart {
 
 export interface ImagePart {
   type: "image"
-  /**
-   * Image data. Can either be:
-   * - data: a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer
-   * - URL: a URL that points to the image
-   */
   image: DataContent | URL
-  /** Optional mime type of the image. */
   mimeType?: string
 }

--- a/liminal/exec.ts
+++ b/liminal/exec.ts
@@ -5,18 +5,19 @@ import type { ActorLike } from "./Actor/ActorLike.ts"
 import { reduce } from "./Actor/reduce.ts"
 import { Scope } from "./Scope.ts"
 import type { ExtractSpec, Spec } from "./Spec.ts"
-import type { U2I } from "./util/U2I.ts"
+import type { FromEntries } from "./util/FromEntries.ts"
 import { unwrapDeferred } from "./util/unwrapDeferred.ts"
 
+// type G = typeof y extends ActorLike<infer Y> ? FromEntries<ExtractSpec<Y>["Entry"]> : never
 export interface ExecConfig<T = any, S extends Spec = Spec> {
-  bind: U2I<S["Field"]>
+  bind: FromEntries<S["Entry"]>
   handler?: (event: EnteredEvent | S["Event"] | ExitedEvent<T>) => any
 }
 
-export async function exec<Y extends ActionLike, T, S extends ExtractSpec<Y>>(
+export async function exec<Y extends ActionLike, T>(
   actorLike: ActorLike<Y, T>,
-  config: ExecConfig<T, S>,
-): Promise<Scope<any>> {
+  config: ExecConfig<T, ExtractSpec<Y>>,
+): Promise<Scope<T>> {
   const actor = unwrapDeferred(actorLike)
   const events = new ActionEvents((inner) => inner, config.handler)
   events.emit({

--- a/liminal/exec.ts
+++ b/liminal/exec.ts
@@ -8,7 +8,6 @@ import type { ExtractSpec, Spec } from "./Spec.ts"
 import type { FromEntries } from "./util/FromEntries.ts"
 import { unwrapDeferred } from "./util/unwrapDeferred.ts"
 
-// type G = typeof y extends ActorLike<infer Y> ? FromEntries<ExtractSpec<Y>["Entry"]> : never
 export interface ExecConfig<T = any, S extends Spec = Spec> {
   bind: FromEntries<S["Entry"]>
   handler?: (event: EnteredEvent | S["Event"] | ExitedEvent<T>) => any

--- a/liminal/patterns/declareEmbeddingModel.ts
+++ b/liminal/patterns/declareEmbeddingModel.ts
@@ -4,11 +4,11 @@ import type { EmbeddingModelSetEvent } from "../actions/SetEmbeddingModel.ts"
 
 export function* declareEmbeddingModel<K extends keyof any>(key: K): Generator<
   | Arg<{
-    Field: { [_ in K]: RunEmbed }
+    Entry: [K, RunEmbed]
     Event: never
   }>
   | SetEmbeddingModel<{
-    Field: never
+    Entry: never
     Event: EmbeddingModelSetEvent<K>
   }>,
   void

--- a/liminal/patterns/declareLanguageModel.ts
+++ b/liminal/patterns/declareLanguageModel.ts
@@ -4,11 +4,11 @@ import type { LanguageModelSetEvent } from "../actions/SetLanguageModel.ts"
 
 export function* declareLanguageModel<K extends keyof any>(key: K): Generator<
   | Arg<{
-    Field: { [_ in K]: RunInfer }
+    Entry: [K, RunInfer]
     Event: never
   }>
   | SetLanguageModel<{
-    Field: never
+    Entry: never
     Event: LanguageModelSetEvent<K>
   }>,
   void

--- a/liminal/patterns/declareXModel.test-type.ts
+++ b/liminal/patterns/declareXModel.test-type.ts
@@ -11,17 +11,13 @@ import { declareLanguageModel } from "./declareLanguageModel.ts"
 
 const languageModel = declareLanguageModel("A")
 ActorAssertions(languageModel).assertSpec<{
-  Field: {
-    A: RunInfer
-  }
+  Entry: ["A", RunInfer]
   Event: LanguageModelSetEvent<"A">
 }>()
 
 const embeddingModel = declareEmbeddingModel("B")
 ActorAssertions(embeddingModel).assertSpec<{
-  Field: {
-    B: RunEmbed
-  }
+  Entry: ["B", RunEmbed]
   Event: EmbeddingModelSetEvent<"B">
 }>()
 
@@ -31,11 +27,7 @@ function* both() {
 }
 
 ActorAssertions(both).assertSpec<{
-  Field: {
-    A: RunInfer
-  } | {
-    B: RunEmbed
-  }
+  Entry: ["A", RunInfer] | ["B", RunEmbed]
   Event: LanguageModelSetEvent<"A"> | EmbeddingModelSetEvent<"B">
 }>()
 
@@ -48,15 +40,11 @@ function* parent() {
 }
 
 ActorAssertions(parent).assertSpec<{
-  Field: {
-    A: RunInfer
-  } | {
-    B: RunEmbed
-  } | {
-    C: RunInfer
-  } | {
-    D: RunEmbed
-  }
+  Entry:
+    | ["A", RunInfer]
+    | ["B", RunEmbed]
+    | ["C", RunInfer]
+    | ["D", RunEmbed]
   Event:
     | LanguageModelSetEvent<"C">
     | EmbeddingModelSetEvent<"D">

--- a/liminal/patterns/declareXModel.test.ts
+++ b/liminal/patterns/declareXModel.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from "bun:test"
 import { context } from "../actions/Context.ts"
+import type { ActionLike } from "../Actor/ActionLike.ts"
+import type { ActorLike } from "../Actor/ActorLike.ts"
 import { exec } from "../exec.ts"
+import type { ExtractSpec } from "../Spec.ts"
 import { TestEmbeddingModel } from "../testing/TestEmbeddingModel/TestEmbeddingModel.ts"
 import { TestLanguageModel } from "../testing/TestLanguageModel/TestLanguageModel.ts"
+import type { FromEntries } from "../util/FromEntries.ts"
 import { declareEmbeddingModel } from "./declareEmbeddingModel.ts"
 import { declareLanguageModel } from "./declareLanguageModel.ts"
 
@@ -28,3 +32,13 @@ describe("Model", () => {
     expect(JSON.stringify(scope, null, 2)).toMatchSnapshot()
   })
 })
+
+function* y() {
+  yield* declareLanguageModel("default")
+  yield* declareLanguageModel("secondary")
+  yield* context("child", function*() {
+    yield* declareLanguageModel("child_a")
+    yield* declareEmbeddingModel("child_b")
+  })
+  yield* declareEmbeddingModel("tertiary")
+}

--- a/liminal/patterns/declareXModel.test.ts
+++ b/liminal/patterns/declareXModel.test.ts
@@ -1,12 +1,8 @@
 import { describe, expect, it } from "bun:test"
 import { context } from "../actions/Context.ts"
-import type { ActionLike } from "../Actor/ActionLike.ts"
-import type { ActorLike } from "../Actor/ActorLike.ts"
 import { exec } from "../exec.ts"
-import type { ExtractSpec } from "../Spec.ts"
 import { TestEmbeddingModel } from "../testing/TestEmbeddingModel/TestEmbeddingModel.ts"
 import { TestLanguageModel } from "../testing/TestLanguageModel/TestLanguageModel.ts"
-import type { FromEntries } from "../util/FromEntries.ts"
 import { declareEmbeddingModel } from "./declareEmbeddingModel.ts"
 import { declareLanguageModel } from "./declareLanguageModel.ts"
 
@@ -32,13 +28,3 @@ describe("Model", () => {
     expect(JSON.stringify(scope, null, 2)).toMatchSnapshot()
   })
 })
-
-function* y() {
-  yield* declareLanguageModel("default")
-  yield* declareLanguageModel("secondary")
-  yield* context("child", function*() {
-    yield* declareLanguageModel("child_a")
-    yield* declareEmbeddingModel("child_b")
-  })
-  yield* declareEmbeddingModel("tertiary")
-}

--- a/liminal/util/FromEntries.ts
+++ b/liminal/util/FromEntries.ts
@@ -1,3 +1,3 @@
 export type FromEntries<E extends [keyof any, any]> = {
-  [K in E[0]]: E extends [K, infer V] ? V : never
+  [K in E[0]]: Extract<E, [K, any]> extends [K, infer V] ? V : never
 }

--- a/liminal/util/FromEntries.ts
+++ b/liminal/util/FromEntries.ts
@@ -1,0 +1,3 @@
+export type FromEntries<E extends [keyof any, any]> = {
+  [K in E[0]]: E extends [K, infer V] ? V : never
+}

--- a/liminal/util/U2I.ts
+++ b/liminal/util/U2I.ts
@@ -1,1 +1,0 @@
-export type U2I<T> = (T extends any ? (x: T) => any : never) extends (x: infer R) => any ? R : never


### PR DESCRIPTION
`Spec["Field"]` -> `Spec["Entry"]`

Represents the arg entries as a union of tuples.

---

Also: `yield* infer(type(string.array()))` or other non-object types now work as root types.