### PR TITLE
Fork Counting

### DIFF
--- a/examples/actors/event_narrowing.ts
+++ b/examples/actors/event_narrowing.ts
@@ -5,6 +5,9 @@ const exec = Exec(g, {
 })
 
 exec((event) => {
+  if (isScopeChildEvent(event, [])) {
+    event
+  }
   if (isScopeChildEvent(event, ["child-a", "child-b", "child-c"])) {
     if (event.type === "emitted") {
       event.value
@@ -12,6 +15,9 @@ exec((event) => {
   }
   if (isScopeChildEvent(event, [])) {
     event.type // no `branched`
+    if (event.type === "returned") {
+      event.value
+    }
   }
   if (event.type === "emitted") {
     event.value

--- a/examples/actors/self_talk.ts
+++ b/examples/actors/self_talk.ts
@@ -10,7 +10,7 @@ export default function*() {
   yield* L.user`Great, please teach something interesting about this choice of subtopic.`
   yield* L.infer()
   let i = 0
-  while (i < 2) {
+  while (i < 3) {
     const userReply = yield* L.branch("infer-user-reply", function*() {
       yield* L.user`Please reply to the last message on my behalf.`
       return yield* L.infer()

--- a/examples/actors/self_talk.ts
+++ b/examples/actors/self_talk.ts
@@ -10,7 +10,7 @@ export default function*() {
   yield* L.user`Great, please teach something interesting about this choice of subtopic.`
   yield* L.infer()
   let i = 0
-  while (i < 5) {
+  while (i < 2) {
     const userReply = yield* L.branch("infer-user-reply", function*() {
       yield* L.user`Please reply to the last message on my behalf.`
       return yield* L.infer()

--- a/liminal/Exec.ts
+++ b/liminal/Exec.ts
@@ -2,14 +2,16 @@ import type { Action } from "./Action.ts"
 import type { Actor } from "./Actor.ts"
 import type { EventHandler } from "./events/EventHandler.ts"
 import type { EventResolved, ExtractEventResolved } from "./events/EventResolved.ts"
-import type { LanguageModel, Model } from "./Model.ts"
+import type { LanguageModel } from "./Model.ts"
 import { RootScope, type Scope } from "./Scope.ts"
 import type { FromEntries } from "./util/FromEntries.ts"
 import type { JSONKey } from "./util/JSONKey.ts"
 
 export interface Exec<Y extends Action = Action, T = any> {
   (
-    handler?: EventHandler<Extract<ExtractEventResolved<Y[""]> & {}, EventResolved>>,
+    handler?: EventHandler<
+      Extract<ExtractEventResolved<Y[""]> & {}, EventResolved>
+    >,
     options?: ExecOptions,
   ): Promise<T>
 }

--- a/liminal/actions/actions_derived/__snapshots__/declareModel.test.ts.snap
+++ b/liminal/actions/actions_derived/__snapshots__/declareModel.test.ts.snap
@@ -4,6 +4,7 @@ exports[`Model generates the expected event sequence 1`] = `
 "[
   {
     "scope": [],
+    "index": 0,
     "type": "model_pushed",
     "modelKey": "secondary",
     "modelType": "language"
@@ -12,12 +13,14 @@ exports[`Model generates the expected event sequence 1`] = `
     "scope": [
       "fork-key"
     ],
+    "index": 0,
     "type": "forked"
   },
   {
     "scope": [
       "fork-key"
     ],
+    "index": 0,
     "type": "model_pushed",
     "modelKey": "child_a",
     "modelType": "language"
@@ -26,6 +29,7 @@ exports[`Model generates the expected event sequence 1`] = `
     "scope": [
       "fork-key"
     ],
+    "index": 0,
     "type": "model_pushed",
     "modelKey": "child_b",
     "modelType": "embedding"
@@ -34,6 +38,7 @@ exports[`Model generates the expected event sequence 1`] = `
     "scope": [
       "fork-key"
     ],
+    "index": 0,
     "type": "model_removed",
     "modelKey": "child_a",
     "modelType": "language"
@@ -42,6 +47,7 @@ exports[`Model generates the expected event sequence 1`] = `
     "scope": [
       "fork-key"
     ],
+    "index": 0,
     "type": "model_removed",
     "modelKey": "child_b",
     "modelType": "embedding"
@@ -50,28 +56,33 @@ exports[`Model generates the expected event sequence 1`] = `
     "scope": [
       "fork-key"
     ],
+    "index": 0,
     "type": "returned"
   },
   {
     "scope": [],
+    "index": 0,
     "type": "model_pushed",
     "modelKey": "tertiary",
     "modelType": "embedding"
   },
   {
     "scope": [],
+    "index": 0,
     "type": "model_removed",
     "modelKey": "secondary",
     "modelType": "language"
   },
   {
     "scope": [],
+    "index": 0,
     "type": "model_removed",
     "modelKey": "tertiary",
     "modelType": "embedding"
   },
   {
     "scope": [],
+    "index": 0,
     "type": "returned"
   }
 ]"

--- a/liminal/events/EventResolved.ts
+++ b/liminal/events/EventResolved.ts
@@ -5,14 +5,26 @@ import type { Forked } from "./Forked.ts"
 import type { LEvent } from "./LEvent.ts"
 import type { Returned } from "./Returned.ts"
 
-export type EventResolved = LEvent & {
+export type EventResolved<E extends LEvent = LEvent> = E & {
   scope: Array<JSONKey>
+  index: number
 }
 
 export type ExtractEventResolved<S extends Spec, P extends Array<JSONKey> = []> =
-  | ([S["Event"]] extends [never] ? never : Expand<{ scope: P } & (S["Event"] | (P extends [] ? never : Forked))>)
+  | ([S["Event"]] extends [never] ? never
+    : Expand<
+      {
+        scope: P
+        index: number
+      } & (S["Event"] | (P extends [] ? never : Forked))
+    >)
   | ([S["Child"]] extends [infer C extends [JSONKey, Spec]] ? {
       [L in C[0]]: ExtractEventResolved<Extract<C, [L, Spec]>[1], [...P, L]>
     }[C[0]]
     : never)
-  | ([S["Value"]] extends [never] ? never : Expand<{ scope: P } & Returned<S>>)
+  | ([S["Value"]] extends [never] ? never : Expand<
+    {
+      scope: P
+      index: number
+    } & Returned<S["Value"]>
+  >)


### PR DESCRIPTION
Scope events now contain an index, indicating which scope instance they belong to.

```ts
{
  scope: [ 'infer-user-reply' ],
  index: 0,
  type: 'inference_requested'
}

// ...

{
  scope: [ 'infer-user-reply' ],
  index: 1,
  type: 'inference_requested'
}
```