### PR TITLE
Add `Runic.E` Utility Type

### DIFF
--- a/liminal.land/events.md
+++ b/liminal.land/events.md
@@ -31,7 +31,7 @@ function* g() {
   yield* L.event({ c: "D" })
 }
 
-type GEvent = Runic.E<typeof g>
+type GRune = Runic.E<typeof g>
 //   ^?
 ```
 

--- a/liminal/Runic.ts
+++ b/liminal/Runic.ts
@@ -15,6 +15,8 @@ export namespace Runic {
     : X extends RuneIterator<Rune, infer T> ? T
     : never
 
+  export type E<X extends Runic> = Y<X>["E"]
+
   export function unwrap<Y extends Rune, T>(runic: Runic<Y, T>): RuneIterator<Y, T> {
     if (Symbol.iterator in runic) {
       return runic[Symbol.iterator]()


### PR DESCRIPTION
A shorthand for `Runic.Y<R>["E"]`