### PR TITLE
Rename `Model` -> `Adapter` + Documentation Fixes

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,14 +79,14 @@
     },
     "liminal": {
       "name": "liminal",
-      "version": "0.5.13",
+      "version": "0.5.16",
       "devDependencies": {
         "conditional-type-checks": "^1.0.6",
       },
     },
     "liminal-strands": {
       "name": "liminal-strands",
-      "version": "0.0.2",
+      "version": "0.0.4",
       "dependencies": {
         "liminal": "^0.5.13",
         "liminal-arktype": "^0.0.6",
@@ -112,7 +112,7 @@
     },
     "packages/liminal-ai": {
       "name": "liminal-ai",
-      "version": "0.0.13",
+      "version": "0.0.15",
       "peerDependencies": {
         "ai": "^4.1.61",
         "liminal": "^0.5.13",
@@ -127,7 +127,7 @@
     },
     "packages/liminal-arktype": {
       "name": "liminal-arktype",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "peerDependencies": {
         "arktype": "^2.1.10",
         "liminal": "^0.5.13",
@@ -135,7 +135,7 @@
     },
     "packages/liminal-effect": {
       "name": "liminal-effect",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "peerDependencies": {
         "effect": "^3.13.12",
         "liminal": "^0.5.13",
@@ -143,14 +143,14 @@
     },
     "packages/liminal-inception": {
       "name": "liminal-inception",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "peerDependencies": {
         "liminal": "^0.5.13",
       },
     },
     "packages/liminal-ollama": {
       "name": "liminal-ollama",
-      "version": "0.0.8",
+      "version": "0.0.11",
       "peerDependencies": {
         "liminal": "^0.5.13",
         "ollama": "^0.5.14",
@@ -158,7 +158,7 @@
     },
     "packages/liminal-openai": {
       "name": "liminal-openai",
-      "version": "0.0.7",
+      "version": "0.0.9",
       "peerDependencies": {
         "liminal": "^0.5.13",
         "openai": "^4.95.1",
@@ -166,7 +166,7 @@
     },
     "packages/liminal-typebox": {
       "name": "liminal-typebox",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "peerDependencies": {
         "@sinclair/typebox": "^0.34.33",
         "ajv": "^8.17.1",
@@ -175,7 +175,7 @@
     },
     "packages/liminal-valibot": {
       "name": "liminal-valibot",
-      "version": "0.0.6",
+      "version": "0.0.8",
       "peerDependencies": {
         "@valibot/to-json-schema": "^1.0.0",
         "liminal": "^0.5.12",
@@ -184,7 +184,7 @@
     },
     "packages/liminal-zod3": {
       "name": "liminal-zod3",
-      "version": "0.0.8",
+      "version": "0.0.11",
       "peerDependencies": {
         "liminal": "0.5.13",
         "zod": "^3.24.2",

--- a/liminal.land/.vitepress/config.mts
+++ b/liminal.land/.vitepress/config.mts
@@ -90,7 +90,7 @@ export default defineConfig({
         text: "Conversation",
         items: [
           { text: "Messages", link: "/messages" },
-          { text: "Models", link: "/models" },
+          { text: "Adapters", link: "/adapters" },
           { text: "Tools", link: "/tools" },
           // { text: "Events", link: "/events" },
           // { text: "Schemas", link: "/schemas" },

--- a/liminal.land/adapters.md
+++ b/liminal.land/adapters.md
@@ -1,4 +1,4 @@
-# Liminal Models <Badge type="warning" text="beta" />
+# Liminal (Model) Adapters <Badge type="warning" text="beta" />
 
 Focus a model adapter with `L.focus`. The specified client adapter will be used
 for subsequent inference.
@@ -42,14 +42,14 @@ function* g() {
 ## Creating Adapters
 
 ```ts
-import { Model } from "liminal"
+import { Adapter } from "liminal"
 import { type Message, Ollama } from "ollama"
 
 // Up to you. Could be a union of model name literals.
 type YourConfig = any
 
-export function adapter(config: YourConfig): Model {
-  return new Model(
+export function adapter(config: YourConfig): Adapter {
+  return new Adapter(
     "your_client_name",
     ({ messages, schema }) => {
       return {

--- a/liminal.land/index.md
+++ b/liminal.land/index.md
@@ -8,11 +8,11 @@ hero:
   tagline: Reusable, branchable, self-evolving conversations.
   actions:
     - theme: brand
-      text: Quickstart
-      link: /start
-    - theme: alt
       text: Overview
       link: /overview
+    - theme: alt
+      text: Quickstart
+      link: /start
 features:
   - icon:
       src: /iconoir--chat-bubble-check.svg

--- a/liminal.land/overview.md
+++ b/liminal.land/overview.md
@@ -1,8 +1,10 @@
 # Overview <Badge type="warning" text="beta" />
 
-> Liminal is in active development. See
+> Liminal is in active development.
+
+<!-- > See
 > [the roadmap](https://github.com/harrysolovay/liminal/issues/319) for more
-> information.
+> information. -->
 
 Liminal provides building blocks for modeling conversations between language
 models.

--- a/liminal.land/start.md
+++ b/liminal.land/start.md
@@ -34,7 +34,7 @@ yarn add liminal liminal-openai
 
 Also install the adapter for your client of choice. Current options include
 OpenAI, Ollama and the Vercel AI SDK (see
-[the adapter documentation](./models.md)).
+[the adapter documentation](./adapters.md)).
 
 ## API Overview
 

--- a/liminal.land/strands.md
+++ b/liminal.land/strands.md
@@ -210,7 +210,7 @@ The following is a non-exhaustive list of Liminal's core runes.
 
 | Factory       | Description                                                                            | Returns                                     |
 | ------------- | -------------------------------------------------------------------------------------- | ------------------------------------------- |
-| `L.adapter`   | Push a new conversation adapter to the stack.                                          | `Adapter`                                   |
+| `L.focus`     | Push a new (model) adapter to the stack.                                               | `Adapter`                                   |
 | `L.system`    | Append a system-role message to the message list.                                      | `void`                                      |
 | `L.user`      | Append a user-role message to the message list.                                        | `void`                                      |
 | `L.assistant` | Append an assistant-role message to the message list.                                  | `void`                                      |

--- a/liminal/AdapterRegistry.ts
+++ b/liminal/AdapterRegistry.ts
@@ -2,14 +2,14 @@ import type { Adapter } from "./Adapter.ts"
 import { LiminalAssertionError } from "./LiminalAssertionError.ts"
 
 /**
- * An intrusive doubly-linked list for storing `Model`s.
+ * An intrusive doubly-linked list for storing `Adapter`s.
  * Provides efficient insertion, removal, and lookups.
  */
 export class AdapterRegistry {
   declare head?: ModelRegistryNode | undefined
   declare tail?: ModelRegistryNode | undefined
 
-  /** Returns the most recently registered model */
+  /** Returns the most recently registered adapter */
   peek() {
     return this.tail?.adapter
   }
@@ -24,8 +24,8 @@ export class AdapterRegistry {
   }
 
   /**
-   * Registers a new model and returns the created node
-   * @param value The model to register
+   * Registers a new adapter and returns the created node
+   * @param value The adapter to register
    */
   register(value: Adapter): ModelRegistryNode {
     const node: ModelRegistryNode = {
@@ -41,7 +41,7 @@ export class AdapterRegistry {
     return node
   }
 
-  /** Remove a model from the registry. */
+  /** Remove a adapter from the registry. */
   remove(node: ModelRegistryNode) {
     if (node.prev) {
       node.prev.next = node.next

--- a/liminal/L/run.ts
+++ b/liminal/L/run.ts
@@ -10,7 +10,6 @@ import type { Tool } from "../Tool.ts"
 /** Configuration options for running a definition. */
 export interface RunConfig<Y extends Rune<any>> {
   handler?: Handler<Y> | undefined
-  models?: AdapterRegistry | undefined
   messages?: Array<Message> | undefined
   tools?: Set<Tool> | undefined
   signal?: AbortSignal | undefined
@@ -19,7 +18,7 @@ export interface RunConfig<Y extends Rune<any>> {
 export function run<Y extends Rune<any>, T>(definition: Definition<Y, T>, config?: RunConfig<Y>): Strand<Y, T> {
   const context = Context({
     handler: config?.handler,
-    adapters: config?.models ?? new AdapterRegistry(),
+    adapters: new AdapterRegistry(),
     messages: config?.messages ?? [],
     tools: config?.tools ?? new Set(),
   })


### PR DESCRIPTION
- Updated typo `L.adapter` to correct factory: `L.focus`
- Rename `Model` to `Adapter`