### PR TITLE
Rename `tools` to `toolkit`

### DIFF
--- a/examples/_common.ts
+++ b/examples/_common.ts
@@ -1,23 +1,14 @@
 import { OpenAiClient, OpenAiLanguageModel } from "@effect/ai-openai"
 import { FetchHttpClient } from "@effect/platform"
-import { Config, Effect, Layer, pipe } from "effect"
+import { Config, Effect, flow } from "effect"
 
-export const provideCommon = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  pipe(
-    effect,
-    Effect.onError((cause) => Effect.logError(cause.toString())),
-    openai,
-  )
-
-export const openai = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
-  pipe(
-    effect,
-    Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
-    Effect.provide(
-      OpenAiClient
-        .layerConfig({
-          apiKey: Config.redacted("OPENAI_API_KEY"),
-        })
-        .pipe(Layer.provide(FetchHttpClient.layer)),
-    ),
-  )
+export const common = flow(
+  Effect.onError((cause) => Effect.logError(cause.toString())),
+  Effect.provide(OpenAiLanguageModel.model("gpt-4o-mini")),
+  Effect.provide(
+    OpenAiClient.layerConfig({
+      apiKey: Config.redacted("OPENAI_API_KEY"),
+    }),
+  ),
+  Effect.provide(FetchHttpClient.layer),
+)

--- a/examples/activity_suggestions.ts
+++ b/examples/activity_suggestions.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 const Activity = Schema.Struct({
   title: Schema.String,
@@ -23,6 +23,6 @@ await Effect.gen(function*() {
   strand({
     system: `When you are asked a question, answer without asking for clarification.`,
   }),
-  provideCommon,
+  common,
   Effect.runPromise,
 )

--- a/examples/chaining.ts
+++ b/examples/chaining.ts
@@ -1,6 +1,6 @@
 import { Console, Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common"
+import { common } from "./_common"
 
 await Effect.gen(function*() {
   console.log("Here")
@@ -38,6 +38,6 @@ await Effect.gen(function*() {
     system: `Write persuasive marketing copy for: Buffy The Vampire Slayer. Focus on benefits and emotional appeal.`,
     handler: Console.log,
   }),
-  provideCommon,
+  common,
   Effect.runPromise,
 ).then(console.log)

--- a/examples/compare_models.ts
+++ b/examples/compare_models.ts
@@ -1,7 +1,7 @@
 import { OpenAiLanguageModel } from "@effect/ai-openai"
 import { Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 await Effect.gen(function*() {
   yield* L.user`Write a rap about type-level programming in TypeScript`
@@ -29,6 +29,6 @@ await Effect.gen(function*() {
   return variants[key]
 }).pipe(
   strand(),
-  provideCommon,
+  common,
   Effect.runPromise,
 )

--- a/examples/optimizer.ts
+++ b/examples/optimizer.ts
@@ -1,6 +1,6 @@
 import { Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 const TEXT = "..."
 
@@ -60,6 +60,6 @@ Effect.gen(function*() {
     system:
       `You are an expert literary translator. Translate the supplied text to the specified target language, preserving tone and cultural nuances.`,
   }),
-  provideCommon,
+  common,
   Effect.runPromise,
 )

--- a/examples/parallel.ts
+++ b/examples/parallel.ts
@@ -2,7 +2,7 @@ import { Path } from "@effect/platform"
 import { BunPath } from "@effect/platform-bun"
 import { Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 const Lmh = Schema.Literal("lower", "medium", "high")
 
@@ -56,7 +56,7 @@ Effect.gen(function*() {
     system: `You are a technical lead summarizing multiple code reviews. Review the supplied code.`,
     handler: Effect.log,
   }),
-  provideCommon,
+  common,
   Effect.provide(BunPath.layer),
   Effect.runPromise,
 )

--- a/examples/routing.ts
+++ b/examples/routing.ts
@@ -1,7 +1,7 @@
 import { OpenAiLanguageModel } from "@effect/ai-openai"
 import { Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 const USE_CLASSIFICATION_PROMPTS = {
   general: "You are an expert customer service representative handling general inquiries.",
@@ -41,6 +41,6 @@ await Effect.gen(function*() {
   return { classification, response }
 }).pipe(
   strand(),
-  provideCommon,
+  common,
   Effect.runPromise,
 ).then(console.log)

--- a/examples/self_talk.ts
+++ b/examples/self_talk.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 await Effect
   .gen(function*() {
@@ -30,7 +30,7 @@ await Effect
         Just reply to the best of your ability given the information you have.
       `,
     }),
-    provideCommon,
+    common,
     Effect.runPromise,
   )
   .then(console.log)

--- a/examples/trip_planner.ts
+++ b/examples/trip_planner.ts
@@ -2,7 +2,7 @@ import { Terminal } from "@effect/platform"
 import { BunTerminal } from "@effect/platform-bun"
 import { Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 const DEPARTURE_LOCATION = "New York City"
 
@@ -32,7 +32,7 @@ await Effect.gen(function*() {
   strand({
     handler: Effect.log,
   }),
-  provideCommon,
+  common,
   Effect.provide(BunTerminal.layer),
   Effect.runPromise,
 ).then(console.log)

--- a/examples/workers.ts
+++ b/examples/workers.ts
@@ -1,6 +1,6 @@
 import { Console, Effect, Schema } from "effect"
 import { L, strand } from "liminal"
-import { provideCommon } from "./_common.ts"
+import { common } from "./_common.ts"
 
 const IMPLEMENTATION_PROMPTS = {
   create: "You are an expert at implementing new files following best practices and project patterns.",
@@ -44,6 +44,6 @@ await Effect
       system: `You are a senior software architect planning feature implementations.`,
       handler: Console.log,
     }),
-    provideCommon,
+    common,
     Effect.runPromise,
   )

--- a/liminal/strand.ts
+++ b/liminal/strand.ts
@@ -11,7 +11,7 @@ export interface StrandOptions<E, R, in out T extends AiTool.Any> {
   /** The liminal event handler. */
   handler?: ((event: LEvent) => Effect.Effect<any, E, R>) | undefined
   /** The tools to use for by strand. */
-  tools?: AiToolkit.AiToolkit<T> | undefined
+  toolkit?: AiToolkit.AiToolkit<T> | undefined
 }
 
 /** Create an isolated clone of the current conversation to provide for an effect. */
@@ -33,6 +33,6 @@ export const strand: <HE = never, HR = never, T extends AiTool.Any = never>(
       Effect.provideService(MessagesRef, messagesRef),
       Effect.provideService(System, options?.system),
       Effect.provideService(Handler, options?.handler),
-      Effect.provideService(Toolkit, options?.tools),
+      Effect.provideService(Toolkit, options?.toolkit),
     ))
   }) as never // TODO


### PR DESCRIPTION
- For uniformity with `@effect/ai`.
- Simpler way of providing common services to examples