### PR TITLE
use patch instead of minor

### DIFF
--- a/.changeset/dark-bobcats-buy.md
+++ b/.changeset/dark-bobcats-buy.md
@@ -1,7 +1,7 @@
 ---
-"liminal": minor
-"liminal-browser": minor
-"liminal-cloudflare": minor
+"liminal": patch
+"liminal-browser": patch
+"liminal-cloudflare": patch
 ---
 
 This version marks a complete reimagining of Liminal. More information coming soon.


### PR DESCRIPTION
Given the peer deps + fixed, changesets tries to skip all deps to 1.0.0 –– for now, patches only!